### PR TITLE
fix: bump axios to 1.17.0 to address HIGH severity CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/react-modal": "^3.16.3",
     "@web3modal/wagmi": "4.0.5",
     "antd": "^5.19.3",
-    "axios": "^1.13.6",
+    "axios": "^1.17.0",
     "bn.js": "^5.2.1",
     "buffer-layout": "^1.2.2",
     "class-variance-authority": "^0.7.0",


### PR DESCRIPTION
Bumps axios from ^1.13.6 to ^1.17.0.

Addresses the following open Dependabot alerts:
- Allocation of Resources Without Limits or Throttling
- Proxy-Authorization credential leak on HTTP→HTTPS redirect
- NO_PROXY bypass via RFC 1122 loopback subnet
- ReDoS via Cookie Name Injection
- Prototype pollution read-side gadgets (credential injection, request hijacking)
- XSRF token cross-origin leakage

All HIGH severity. Run `npm install` after merging to update the lock file.